### PR TITLE
Add wall distance simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
         window.MathJax = { tex: {inlineMath: [['$','$'], ['\\(','\\)']]}, svg: {fontCache: 'global'} };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js" async></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/examples/js/loaders/GLTFLoader.js"></script>
     <style>
         * {
             margin: 0;
@@ -430,7 +432,7 @@
                 <input type="number" id="distanceInput" step="0.1" placeholder="Örnek: 500">
                 <button type="button" class="btn" onclick="addMeasurement()">Ekle</button>
             </div>
-            <canvas id="simulationCanvas" width="600" height="200"></canvas>
+            <div id="simulation3d" style="width:600px; height:400px;"></div>
         </div>
     </div>
 
@@ -641,66 +643,75 @@
             if (formulaBox) formulaBox.style.display = 'none';
         }
 
-        // ---- Duvar Mesafe Simülasyonu ----
-        const measurements = [];
-        const vehicleHeight = 180; // cm
-        const cameraHeight = 150;  // yaklaşık kamera yüksekliği (cm)
+        // ---- Duvar Mesafe Simülasyonu (3D) ----
+        let scene, renderer, camera3d, wall;
+        const measurementSpheres = [];
+
+        function init3DSimulation() {
+            const container = document.getElementById('simulation3d');
+            if (!container) return;
+
+            scene = new THREE.Scene();
+            renderer = new THREE.WebGLRenderer({ antialias: true });
+            renderer.setSize(container.clientWidth, container.clientHeight);
+            container.appendChild(renderer.domElement);
+
+            camera3d = new THREE.PerspectiveCamera(60, container.clientWidth / container.clientHeight, 0.1, 100);
+            camera3d.position.set(-5, 1.5, 5);
+            camera3d.lookAt(0, 1.5, 0);
+
+            // Aydınlatma
+            scene.add(new THREE.HemisphereLight(0xffffff, 0x444444, 1));
+            const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+            dirLight.position.set(5, 10, 7.5);
+            scene.add(dirLight);
+
+            // Zemin
+            const ground = new THREE.Mesh(new THREE.PlaneGeometry(20, 20), new THREE.MeshStandardMaterial({color: 0x999999}));
+            ground.rotation.x = -Math.PI / 2;
+            scene.add(ground);
+
+            // Araç modeli
+            const loader = new THREE.GLTFLoader();
+            loader.load('models/m113a1.glb', gltf => {
+                const model = gltf.scene;
+                model.scale.set(0.01, 0.01, 0.01);
+                scene.add(model);
+            });
+
+            // Duvar
+            wall = new THREE.Mesh(new THREE.PlaneGeometry(5, 3), new THREE.MeshStandardMaterial({color: 0xcccccc, side: THREE.DoubleSide}));
+            wall.position.set(5, 1.5, 0);
+            scene.add(wall);
+
+            animate();
+        }
+
+        function animate() {
+            requestAnimationFrame(animate);
+            renderer.render(scene, camera3d);
+        }
 
         function addMeasurement() {
             const input = document.getElementById('distanceInput');
             const dist = parseFloat(input.value);
             if (isNaN(dist) || dist <= 0) return;
-            measurements.push(dist);
+
+            const distMeters = dist / 100; // cm'den metreye
+            wall.position.x = distMeters;
+
+            const sphere = new THREE.Mesh(
+                new THREE.SphereGeometry(0.1, 16, 16),
+                new THREE.MeshStandardMaterial({ color: 0xff0000 })
+            );
+            sphere.position.set(distMeters, 1.5, (Math.random() - 0.5) * 2);
+            scene.add(sphere);
+            measurementSpheres.push(sphere);
+
             input.value = '';
-            drawSimulation();
         }
 
-        function drawSimulation() {
-            const canvas = document.getElementById('simulationCanvas');
-            if (!canvas) return;
-            const ctx = canvas.getContext('2d');
-            const width = canvas.width;
-            const height = canvas.height;
-            ctx.clearRect(0, 0, width, height);
-
-            const margin = 20;
-            const vehicleWidth = 400; // cm
-            const maxDist = Math.max(...measurements, 500);
-            const scaleX = (width - 2 * margin) / (vehicleWidth + maxDist);
-            const scaleY = (height - 2 * margin) / vehicleHeight;
-
-            const vehiclePxWidth = vehicleWidth * scaleX;
-            const vehiclePxHeight = vehicleHeight * scaleY;
-
-            // Araç çizimi
-            ctx.fillStyle = '#6c757d';
-            ctx.fillRect(margin, height - vehiclePxHeight - margin, vehiclePxWidth, vehiclePxHeight);
-
-            // Kamera konumu
-            const camX = margin + vehiclePxWidth;
-            const camY = height - margin - cameraHeight * scaleY;
-            ctx.fillStyle = '#e63946';
-            ctx.beginPath();
-            ctx.arc(camX, camY, 5, 0, Math.PI * 2);
-            ctx.fill();
-
-            // Ölçümler
-            ctx.strokeStyle = '#343a40';
-            ctx.fillStyle = '#1d3557';
-            measurements.forEach(d => {
-                const x = camX + d * scaleX;
-                ctx.beginPath();
-                ctx.moveTo(x, margin);
-                ctx.lineTo(x, height - margin);
-                ctx.stroke();
-
-                ctx.beginPath();
-                ctx.arc(x, camY, 4, 0, Math.PI * 2);
-                ctx.fill();
-            });
-        }
-
-        drawSimulation();
+        init3DSimulation();
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,6 @@
         window.MathJax = { tex: {inlineMath: [['$','$'], ['\\(','\\)']]}, svg: {fontCache: 'global'} };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js" async></script>
-    <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/build/three.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/examples/js/loaders/GLTFLoader.js"></script>
     <style>
         * {
             margin: 0;
@@ -329,8 +327,8 @@
         <div class="subtitle">Dik ve çapraz bakış açılarını hassas bir şekilde ölçün</div>
         
         <div class="mode-selector">
-            <button class="mode-btn active" onclick="switchMode('normal')">📐 Dik Bakış</button>
-            <button class="mode-btn" onclick="switchMode('angled')">📏 Çapraz Bakış</button>
+            <button class="mode-btn active" id="normalModeBtn">📐 Dik Bakış</button>
+            <button class="mode-btn" id="angledModeBtn">📏 Çapraz Bakış</button>
         </div>
 
         <!-- Normal (Dik) Mod -->
@@ -394,7 +392,7 @@
             </form>
         </div>
 
-        <button type="button" class="btn reset-btn" onclick="resetForm()">🔄 Temizle</button>
+        <button type="button" class="btn reset-btn" id="resetBtn">🔄 Temizle</button>
 
         <div class="error" id="errorMessage"></div>
 
@@ -430,29 +428,37 @@
             <div class="input-group">
                 <label for="distanceInput">📏 Duvara olan mesafe (cm):</label>
                 <input type="number" id="distanceInput" step="0.1" placeholder="Örnek: 500">
-                <button type="button" class="btn" onclick="addMeasurement()">Ekle</button>
+                <button type="button" class="btn" id="addMeasurementBtn">Ekle</button>
             </div>
             <div id="simulation3d" style="width:600px; height:400px;"></div>
         </div>
     </div>
 
-    <script>
+    <script type="module">
+        import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.158.0/build/three.module.js';
+        import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.158.0/examples/jsm/loaders/GLTFLoader.js';
+
         let currentMode = 'normal';
 
-        function switchMode(mode) {
+        function switchMode(mode, evt) {
             currentMode = mode;
-            
+
             // Butonları güncelle
             document.querySelectorAll('.mode-btn').forEach(btn => btn.classList.remove('active'));
-            event.target.classList.add('active');
-            
+            if (evt && evt.currentTarget) {
+                evt.currentTarget.classList.add('active');
+            }
+
             // Bölümleri göster/gizle
             document.querySelectorAll('.input-section').forEach(section => section.classList.remove('active'));
             document.getElementById(mode + '-section').classList.add('active');
-            
+
             // Sonuçları temizle
             resetForm();
         }
+
+        document.getElementById('normalModeBtn').addEventListener('click', e => switchMode('normal', e));
+        document.getElementById('angledModeBtn').addEventListener('click', e => switchMode('angled', e));
 
         document.getElementById('normalForm').addEventListener('submit', function(e) {
             e.preventDefault();
@@ -463,6 +469,8 @@
             e.preventDefault();
             hesaplaCaprazAci();
         });
+
+        document.getElementById('resetBtn').addEventListener('click', resetForm);
 
         function hesaplaNormalAci() {
             document.getElementById('errorMessage').style.display = 'none';
@@ -672,7 +680,7 @@
             scene.add(ground);
 
             // Araç modeli
-            const loader = new THREE.GLTFLoader();
+            const loader = new GLTFLoader();
             loader.load('models/m113a1.glb', gltf => {
                 const model = gltf.scene;
                 model.scale.set(0.01, 0.01, 0.01);
@@ -693,6 +701,11 @@
         }
 
         function addMeasurement() {
+            if (!wall) {
+                console.warn('Wall not initialized yet');
+                return;
+            }
+
             const input = document.getElementById('distanceInput');
             const dist = parseFloat(input.value);
             if (isNaN(dist) || dist <= 0) return;
@@ -710,6 +723,8 @@
 
             input.value = '';
         }
+
+        document.getElementById('addMeasurementBtn').addEventListener('click', addMeasurement);
 
         init3DSimulation();
     </script>

--- a/index.html
+++ b/index.html
@@ -287,6 +287,19 @@
             margin-top: 5px;
         }
 
+        .simulation {
+            margin-top: 40px;
+            text-align: center;
+        }
+
+        #simulationCanvas {
+            border: 1px solid #dee2e6;
+            width: 100%;
+            max-width: 600px;
+            height: 200px;
+            margin-top: 15px;
+        }
+
         @media (max-width: 480px) {
             .container {
                 padding: 20px;
@@ -408,6 +421,16 @@
                 <h4>🧪 Adım Adım Hesaplama</h4>
                 <div id="formulaContent"></div>
             </div>
+        </div>
+
+        <div class="simulation">
+            <h2>🧱 Duvar Mesafe Simülasyonu</h2>
+            <div class="input-group">
+                <label for="distanceInput">📏 Duvara olan mesafe (cm):</label>
+                <input type="number" id="distanceInput" step="0.1" placeholder="Örnek: 500">
+                <button type="button" class="btn" onclick="addMeasurement()">Ekle</button>
+            </div>
+            <canvas id="simulationCanvas" width="600" height="200"></canvas>
         </div>
     </div>
 
@@ -617,6 +640,67 @@
             const formulaBox = document.getElementById('formulaSteps');
             if (formulaBox) formulaBox.style.display = 'none';
         }
+
+        // ---- Duvar Mesafe Simülasyonu ----
+        const measurements = [];
+        const vehicleHeight = 180; // cm
+        const cameraHeight = 150;  // yaklaşık kamera yüksekliği (cm)
+
+        function addMeasurement() {
+            const input = document.getElementById('distanceInput');
+            const dist = parseFloat(input.value);
+            if (isNaN(dist) || dist <= 0) return;
+            measurements.push(dist);
+            input.value = '';
+            drawSimulation();
+        }
+
+        function drawSimulation() {
+            const canvas = document.getElementById('simulationCanvas');
+            if (!canvas) return;
+            const ctx = canvas.getContext('2d');
+            const width = canvas.width;
+            const height = canvas.height;
+            ctx.clearRect(0, 0, width, height);
+
+            const margin = 20;
+            const vehicleWidth = 400; // cm
+            const maxDist = Math.max(...measurements, 500);
+            const scaleX = (width - 2 * margin) / (vehicleWidth + maxDist);
+            const scaleY = (height - 2 * margin) / vehicleHeight;
+
+            const vehiclePxWidth = vehicleWidth * scaleX;
+            const vehiclePxHeight = vehicleHeight * scaleY;
+
+            // Araç çizimi
+            ctx.fillStyle = '#6c757d';
+            ctx.fillRect(margin, height - vehiclePxHeight - margin, vehiclePxWidth, vehiclePxHeight);
+
+            // Kamera konumu
+            const camX = margin + vehiclePxWidth;
+            const camY = height - margin - cameraHeight * scaleY;
+            ctx.fillStyle = '#e63946';
+            ctx.beginPath();
+            ctx.arc(camX, camY, 5, 0, Math.PI * 2);
+            ctx.fill();
+
+            // Ölçümler
+            ctx.strokeStyle = '#343a40';
+            ctx.fillStyle = '#1d3557';
+            measurements.forEach(d => {
+                const x = camX + d * scaleX;
+                ctx.beginPath();
+                ctx.moveTo(x, margin);
+                ctx.lineTo(x, height - margin);
+                ctx.stroke();
+
+                ctx.beginPath();
+                ctx.arc(x, camY, 4, 0, Math.PI * 2);
+                ctx.fill();
+            });
+        }
+
+        drawSimulation();
     </script>
 </body>
 </html>

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,2 @@
+Place the M113A1 vehicle model here as `m113a1.glb`.
+The 3D simulation in index.html expects this file to exist.


### PR DESCRIPTION
## Summary
- add simulation section to visualize wall distance
- draw measurement points on a canvas with vehicle and wall

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae95655e508320963c8e2b6db9f681